### PR TITLE
print crossdock label dialog improvements

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -13,6 +13,7 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+    implementation "androidx.compose.ui:ui:$compose_ui_version"
 }
 
 ext {

--- a/build.gradle
+++ b/build.gradle
@@ -4,8 +4,8 @@ import io.dock2dock.android.Configuration
 buildscript {
     apply from: 'dependencies.gradle'
     ext {
-        compose_ui_version = '1.4.1'
-        kotlinVersion = '1.8.0'
+        compose_ui_version = '1.4.2'
+        kotlinVersion = '1.8.10'
     }
 
     repositories {

--- a/buildSrc/src/main/java/io/dock2dock/android/Configuration.kt
+++ b/buildSrc/src/main/java/io/dock2dock/android/Configuration.kt
@@ -4,7 +4,7 @@ object Configuration {
     const val minSdk = 23
     const val majorVersion = 0
     const val minorVersion = 0
-    const val patchVersion = 15
+    const val patchVersion = 16
     const val versionName = "$majorVersion.$minorVersion.$patchVersion"
     const val snapshotVersionName = "$majorVersion.$minorVersion.${patchVersion + 1}-SNAPSHOT"
     const val artifactGroup = "io.dock2dock"

--- a/crossdock/src/main/java/io/dock2dock/android/dialogs/PrintCrossdockLabelDialog.kt
+++ b/crossdock/src/main/java/io/dock2dock/android/dialogs/PrintCrossdockLabelDialog.kt
@@ -2,26 +2,27 @@ package io.dock2dock.android.dialogs
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.OutlinedButton
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import io.dock2dock.android.components.BasicDropdownMenuItem
 import io.dock2dock.android.components.ButtonVariant
 import io.dock2dock.android.components.Dock2DockNumberTextField
@@ -44,13 +45,21 @@ internal fun DialogPrintCrossdockLabel(visible: Boolean,
     if (visible) {
         val viewModel = DialogPrintCrossdockLabelViewModel(
             salesOrderNo = salesOrderNo,
-            onSuccess = onSuccessRequest)
-        Dialog(onDismissRequest = {
-            onDismissRequest()
-        })
-        {
+            onSuccess = onSuccessRequest
+        )
+
+        Dialog(
+            properties = DialogProperties(
+                dismissOnClickOutside = false,
+                decorFitsSystemWindows = false,
+                usePlatformDefaultWidth = false
+            ),
+            onDismissRequest = { onDismissRequest() }
+        ) {
+
             DialogPrintCrossdockLabelContent(viewModel, onDismissRequest)
         }
+
     }
 }
 
@@ -61,18 +70,13 @@ internal fun DialogPrintCrossdockLabelContent(viewModel: DialogPrintCrossdockLab
 
     val errorMessage by viewModel.loadError.observeAsState("")
 
-    LaunchedEffect(key1 = Unit) {
-        viewModel.load()
-    }
+    val scrollState = rememberScrollState()
 
     Surface(
-        modifier = Modifier
-            .fillMaxWidth()
-            .wrapContentHeight(),
-        shape = RoundedCornerShape(size = 8.dp)
+        modifier = Modifier.imePadding().fillMaxSize(),
+        color = Color.White
     ) {
-
-        Column(modifier = Modifier.padding(all = 24.dp)) {
+        Column(modifier = Modifier.padding(16.dp)) {
 
             Dock2DockDialogHeader(title = "Print Crossdock Label", onDismissRequest)
 
@@ -80,9 +84,12 @@ internal fun DialogPrintCrossdockLabelContent(viewModel: DialogPrintCrossdockLab
                 ValidationErrorMessage(errorMessage)
             }
 
-            Column(modifier = Modifier
-                .verticalScroll(rememberScrollState(), true)
-                .weight(1f, false)) {
+            Column(
+                Modifier
+                    .weight(1f, true)
+                    .verticalScroll(scrollState)
+            ) {
+
                 FormItem("Sales Order No") {
                     Dock2DockTextField(
                         readOnly = true,
@@ -108,18 +115,6 @@ internal fun DialogPrintCrossdockLabelContent(viewModel: DialogPrintCrossdockLab
                     }
                 }
 
-                FormItem(title = "Quantity") {
-                    Dock2DockNumberTextField(
-                        value = viewModel.quantity,
-                        valueChanged = {
-                            viewModel.onQuantityValueChanged(it)
-                        },
-                        errorMessage = viewModel.quantityValidationMessage,
-                        isError = viewModel.quantityIsError,
-                        placeholderText = "Quantity"
-                    )
-                }
-
                 FormItem(title = "Printer") {
                     FluentDropdown(
                         options = viewModel.printers,
@@ -133,6 +128,19 @@ internal fun DialogPrintCrossdockLabelContent(viewModel: DialogPrintCrossdockLab
                         }) {
                         SubTitleDropdownMenuItem(it.name, it.location)
                     }
+
+                }
+
+                FormItem(title = "Quantity") {
+                    Dock2DockNumberTextField(
+                        value = viewModel.quantity,
+                        valueChanged = {
+                            viewModel.onQuantityValueChanged(it)
+                        },
+                        errorMessage = viewModel.quantityValidationMessage,
+                        isError = viewModel.quantityIsError,
+                        placeholderText = "Quantity"
+                    )
                 }
             }
             Dock2DockDialogFooter {
@@ -141,19 +149,21 @@ internal fun DialogPrintCrossdockLabelContent(viewModel: DialogPrintCrossdockLab
                         onDismissRequest()
                     },
                     shape = RectangleShape,
+                    modifier = Modifier.weight(1f).heightIn(min = 32.dp),
                     border = BorderStroke(1.dp, PrimaryDark),
                     colors = ButtonDefaults.buttonColors(
                         contentColor = PrimaryDark,
                         backgroundColor = Transparent
-                    ),
-                    modifier = Modifier.weight(1f)) {
+                    )
+                ) {
                     Text("Cancel")
                 }
                 PrimaryButton(
                     text = "Print",
                     modifier = Modifier.weight(1f),
                     variant = ButtonVariant.Primary,
-                    isLoading = isLoading) {
+                    isLoading = isLoading
+                ) {
                     viewModel.onSubmit()
                 }
             }

--- a/crossdock/src/main/java/io/dock2dock/android/viewModels/CrossdockLabelDataTableViewModel.kt
+++ b/crossdock/src/main/java/io/dock2dock/android/viewModels/CrossdockLabelDataTableViewModel.kt
@@ -87,6 +87,7 @@ internal class CrossdockLabelDataTableViewModel(
                     }
                 }
             }.onException {
+                print("Error getting sales order. ${this.message}")
                 _errorMessage.value = SERVER_NETWORK_ERROR
             }
             onIsLoadingChange(false)

--- a/crossdock/src/main/java/io/dock2dock/android/viewModels/DialogPrintCrossdockLabelViewModel.kt
+++ b/crossdock/src/main/java/io/dock2dock/android/viewModels/DialogPrintCrossdockLabelViewModel.kt
@@ -51,7 +51,7 @@ internal class DialogPrintCrossdockLabelViewModel(val onSuccess: () -> Unit,
 
     private val dock2dockConfiguration = Dock2DockConfiguration.instance()
 
-    fun load() {
+    init {
         getHandlingUnits()
         getPrinters()
     }

--- a/example/src/main/AndroidManifest.xml
+++ b/example/src/main/AndroidManifest.xml
@@ -11,11 +11,11 @@
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:usesCleartextTraffic="true"
-        android:networkSecurityConfig="@xml/network_security_config"
         tools:targetApi="31">
         <activity
             android:name=".MainActivity"
             android:theme="@style/AppTheme"
+            android:windowSoftInputMode="adjustResize"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/example/src/main/java/io/dock2dock/activities/MainActivity.kt
+++ b/example/src/main/java/io/dock2dock/activities/MainActivity.kt
@@ -2,6 +2,7 @@ package io.dock2dock.activities
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.WindowCompat
 import io.dock2dock.activities.databinding.ActivityPickItemBinding
 import io.dock2dock.adapters.FragmentModel
 import io.dock2dock.adapters.PagerAdapter
@@ -16,7 +17,9 @@ class MainActivity : AppCompatActivity() {
     private lateinit var binding: ActivityPickItemBinding
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        Dock2DockConfiguration.init(this, BuildConfig.Dock2Dock_ApiKey, "https://api.nonprod.dock2dock.io/")
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+
+        Dock2DockConfiguration.init(this, BuildConfig.Dock2Dock_ApiKey, "http://localhost:3000/")
 
         binding = ActivityPickItemBinding.inflate(layoutInflater)
         val view = binding.root
@@ -29,7 +32,7 @@ class MainActivity : AppCompatActivity() {
     private lateinit var fragAdapter: PagerAdapter
 
     var formatter = SimpleDateFormat("E dd MMMM")
-    private val salesOrderNo = "42202"
+    private val salesOrderNo = "SO1002"
 
     private fun setupFragment() {
         fragAdapter = PagerAdapter(supportFragmentManager)

--- a/ui/src/main/java/io/dock2dock/android/components/Dock2DockTextField.kt
+++ b/ui/src/main/java/io/dock2dock/android/components/Dock2DockTextField.kt
@@ -1,6 +1,7 @@
 package io.dock2dock.android.components
 
 import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
@@ -47,7 +48,7 @@ fun Dock2DockTextField(
         onValueChange = {
             valueChanged(it)
         },
-        modifier = Modifier.defaultMinSize(minHeight = 32.dp),
+        modifier = Modifier.defaultMinSize(minHeight = 32.dp).fillMaxWidth(),
         shape = RoundedCornerShape(0),
         keyboardOptions = KeyboardOptions.Default.copy(
             keyboardType = keyboardType,

--- a/ui/src/main/java/io/dock2dock/android/components/PrimaryButton.kt
+++ b/ui/src/main/java/io/dock2dock/android/components/PrimaryButton.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.Button
@@ -71,7 +72,7 @@ fun PrimaryButton(text: String,
         onClick = onClick,
         shape = RectangleShape,
         enabled = true,
-        modifier = modifier,
+        modifier = modifier.heightIn(min = 32.dp),
         colors = getButtonColors(variant = variant),
     ) {
         if (isLoading) {


### PR DESCRIPTION
updated configuration to 0.0.16
create/print label - form items scroll up when keyboard open and action buttons will always show removed android:networkSecurityConfig
made dock2dockTextField fill full width