### PR TITLE
Feature/add lp configurable settings (#33)

### DIFF
--- a/application/src/main/java/io/dock2dock/android/application/configuration/Dock2DockConfiguration.kt
+++ b/application/src/main/java/io/dock2dock/android/application/configuration/Dock2DockConfiguration.kt
@@ -33,7 +33,15 @@ internal constructor(
     }
 
     fun getPrintCrossdockLabelSetting(): Boolean {
-        return userPreferences.getBoolean(DEFAULT_PRINT_CROSSDOCK_LBL_SETTING)
+        return userPreferences.getBoolean(DEFAULT_PRINT_CROSSDOCK_LBL_SETTING, true)
+    }
+
+    fun updateShowLPQuickCreateViewSetting(value: Boolean) {
+        userPreferences.update(DEFAULT_SHOW_LP_QUICK_CREATE_VIEW_SETTING, value)
+    }
+
+    fun getShowLPQuickCreateViewSetting(): Boolean {
+        return userPreferences.getBoolean(DEFAULT_SHOW_LP_QUICK_CREATE_VIEW_SETTING, true)
     }
 
     companion object {
@@ -42,6 +50,7 @@ internal constructor(
         private const val DEFAULT_HANDLING_UNIT = "default_handling_unit"
         private const val DEFAULT_PRINTER = "default_printer"
         private const val DEFAULT_PRINT_CROSSDOCK_LBL_SETTING = "default_print_crossdock_label"
+        private const val DEFAULT_SHOW_LP_QUICK_CREATE_VIEW_SETTING = "default_show_lp_quick_create_view_settings"
         private const val PUBLIC_API_BASEURL = "https://api.dock2dock.io/"
 
         @JvmStatic

--- a/application/src/main/java/io/dock2dock/android/application/events/Dock2DockEvent.kt
+++ b/application/src/main/java/io/dock2dock/android/application/events/Dock2DockEvent.kt
@@ -14,3 +14,11 @@ data class Dock2DockSalesOrderRetrievedEvent(
 data class Dock2DockDefaultHandlingUnitChangedEvent(
     val handlingUnit: CrossdockHandlingUnit
 )
+
+data class Dock2DockShowLPQuickCreateViewChangedEvent(
+    val value: Boolean
+)
+
+data class Dock2DockLpPrintCrossdockLabelChangedEvent(
+    val value: Boolean
+)

--- a/application/src/main/java/io/dock2dock/android/application/storage/UserPreferencesStorage.kt
+++ b/application/src/main/java/io/dock2dock/android/application/storage/UserPreferencesStorage.kt
@@ -12,8 +12,8 @@ internal class UserPreferencesStorage(context: Context) {
         return getString(key, "") ?: ""
     }
 
-    fun getBoolean(key: String): Boolean = prefs.run {
-        return getBoolean(key, false)
+    fun getBoolean(key: String, defaultValue: Boolean): Boolean = prefs.run {
+        return getBoolean(key, defaultValue)
     }
 
     fun clear() = prefs.edit().clear().apply()

--- a/buildSrc/src/main/java/io/dock2dock/android/Configuration.kt
+++ b/buildSrc/src/main/java/io/dock2dock/android/Configuration.kt
@@ -4,7 +4,7 @@ object Configuration {
     const val minSdk = 23
     const val majorVersion = 0
     const val minorVersion = 1
-    const val patchVersion = 3
+    const val patchVersion = 4
     const val versionName = "$majorVersion.$minorVersion.$patchVersion"
     const val snapshotVersionName = "$majorVersion.$minorVersion.${patchVersion + 1}-SNAPSHOT"
     const val artifactGroup = "io.dock2dock"

--- a/crossdock/src/main/java/io/dock2dock/android/crossdock/components/LicensePlateQuickCreateScreen.kt
+++ b/crossdock/src/main/java/io/dock2dock/android/crossdock/components/LicensePlateQuickCreateScreen.kt
@@ -34,7 +34,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.zIndex
 import io.dock2dock.android.application.configuration.Dock2DockConfiguration
-import io.dock2dock.android.crossdock.viewModels.LicensePlateSettingsViewModel
+import io.dock2dock.android.crossdock.viewModels.LicensePlateQuickCreateViewModel
 import io.dock2dock.android.ui.components.BasicDropdownMenuItem
 import io.dock2dock.android.ui.components.FluentDropdown
 import io.dock2dock.android.ui.dialogs.ErrorDialog
@@ -44,7 +44,7 @@ import io.dock2dock.android.ui.theme.PrimaryWhite
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @Composable
-fun LicensePlateSettingsScreen(viewModel: LicensePlateSettingsViewModel) {
+fun LicensePlateQuickCreateScreen(visible: Boolean, viewModel: LicensePlateQuickCreateViewModel) {
 
     val errorMessage by viewModel.errorMessage.collectAsState("")
     val showErrorDialog by viewModel.showErrorDialog.observeAsState(false)
@@ -56,11 +56,13 @@ fun LicensePlateSettingsScreen(viewModel: LicensePlateSettingsViewModel) {
         onConfirm = viewModel::onCloseErrorDialog
     )
 
-    LicensePlateSettingsContent(viewModel)
+    if (visible) {
+        LicensePlateQuickCreateContent(viewModel)
+    }
 }
 
 @Composable
-fun LicensePlateSettingsContent(viewModel: LicensePlateSettingsViewModel) {
+fun LicensePlateQuickCreateContent(viewModel: LicensePlateQuickCreateViewModel) {
     val isOnAddLoading by viewModel.onAddIsLoading.collectAsState(false)
 
     CompositionLocalProvider(LocalContentColor provides Color.White) {
@@ -152,9 +154,9 @@ fun LicensePlateSettingsContent(viewModel: LicensePlateSettingsViewModel) {
 internal fun PreviewLicensePlateSettingsContent_ShowPrintCrossdockLabel() {
     val context = LocalContext.current
     Dock2DockConfiguration.init(context, "")
-    val viewModel = LicensePlateSettingsViewModel("SO1002")
+    val viewModel = LicensePlateQuickCreateViewModel("SO1002")
     viewModel.showPrintCrossdockLabel = true
-    LicensePlateSettingsScreen(viewModel)
+    LicensePlateQuickCreateScreen(true, viewModel)
 }
 
 @Preview(showBackground = true, backgroundColor = 0xFFFFFF, widthDp = 330)
@@ -162,7 +164,7 @@ internal fun PreviewLicensePlateSettingsContent_ShowPrintCrossdockLabel() {
 internal fun PreviewLicensePlateSettingsContent_HidePrintCrossdockLabel() {
     val context = LocalContext.current
     Dock2DockConfiguration.init(context, "")
-    val viewModel = LicensePlateSettingsViewModel("SO1002")
+    val viewModel = LicensePlateQuickCreateViewModel("SO1002")
     viewModel.showPrintCrossdockLabel = false
-    LicensePlateSettingsScreen(viewModel)
+    LicensePlateQuickCreateScreen(true, viewModel)
 }

--- a/crossdock/src/main/java/io/dock2dock/android/crossdock/components/LicensePlateScreen.kt
+++ b/crossdock/src/main/java/io/dock2dock/android/crossdock/components/LicensePlateScreen.kt
@@ -51,6 +51,7 @@ fun LicensePlateScreen(
     viewModel: LicensePlateViewModel
 ) {
     val licensePlate by viewModel.licensePlate.collectAsState(null)
+    val showLPQuickCreateView by viewModel.showLPQuickCreateView.collectAsState(false)
 
     val showLinesSheetState = rememberBottomSheetState()
 
@@ -71,7 +72,7 @@ fun LicensePlateScreen(
         )
         LicensePlateLinesBottomSheet(showLinesSheetState, lp.no)
     } ?: run {
-        LicensePlateSettingsScreen(viewModel.lpSettingsViewModel)
+        LicensePlateQuickCreateScreen(showLPQuickCreateView, viewModel.lpSettingsViewModel)
     }
 }
 
@@ -93,11 +94,12 @@ fun LicensePlateContent(
 
     CompositionLocalProvider(LocalContentColor provides Color.White) {
         Row {
-            Column(Modifier
-                .fillMaxWidth()
-                .zIndex(1f)
-                .background(color = PrimaryOxfordBlue)
-                .padding(start = 8.dp, end = 8.dp, top = 8.dp, bottom = 0.dp)
+            Column(
+                Modifier
+                    .fillMaxWidth()
+                    .zIndex(1f)
+                    .background(color = PrimaryOxfordBlue)
+                    .padding(start = 8.dp, end = 8.dp, top = 8.dp, bottom = 0.dp)
             ) {
                 Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
                     Column {

--- a/crossdock/src/main/java/io/dock2dock/android/crossdock/dialogs/SettingsDialog.kt
+++ b/crossdock/src/main/java/io/dock2dock/android/crossdock/dialogs/SettingsDialog.kt
@@ -23,8 +23,11 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import io.dock2dock.android.application.configuration.Dock2DockConfiguration
 import io.dock2dock.android.crossdock.viewModels.SettingsDialogViewModel
 import io.dock2dock.android.ui.components.BasicDropdownMenuItem
+import io.dock2dock.android.ui.components.Dock2DockSwitch
 import io.dock2dock.android.ui.components.FluentDropdown
 import io.dock2dock.android.ui.components.FormItem
+import io.dock2dock.android.ui.components.FormItemLayout
+import io.dock2dock.android.ui.components.FormSectionHeader
 import io.dock2dock.android.ui.components.SubTitleDropdownMenuItem
 import io.dock2dock.android.ui.theme.PrimaryOxfordBlue
 import io.dock2dock.android.ui.theme.PrimaryWhite
@@ -74,6 +77,7 @@ internal fun SettingsDialogUI(viewModel: SettingsDialogViewModel = viewModel(), 
         ) { paddingValues ->
             Column(modifier = Modifier.padding(paddingValues).padding(24.dp)) {
 
+                FormSectionHeader("Defaults") {
                     FormItem("Default Handling Unit") {
                         FluentDropdown(
                             options = viewModel.handlingUnits,
@@ -102,6 +106,21 @@ internal fun SettingsDialogUI(viewModel: SettingsDialogViewModel = viewModel(), 
                             SubTitleDropdownMenuItem(it.name, it.location)
                         }
                     }
+                }
+
+                FormSectionHeader("License Plate") {
+                    FormItem("Show quick create view", FormItemLayout.Horizontal) {
+                        Dock2DockSwitch(viewModel.showLpQuickCreateView) {
+                            viewModel.onShowLpQuickCreateViewChanged(it)
+                        }
+
+                    }
+                    FormItem("Print cross-dock label", FormItemLayout.Horizontal) {
+                        Dock2DockSwitch(viewModel.lpPrintCrossdockLabel) {
+                            viewModel.onLpPrintCrossdockLabelChanged(it)
+                        }
+                    }
+                }
             }
         }
     }

--- a/crossdock/src/main/java/io/dock2dock/android/crossdock/viewModels/LicensePlateQuickCreateViewModel.kt
+++ b/crossdock/src/main/java/io/dock2dock/android/crossdock/viewModels/LicensePlateQuickCreateViewModel.kt
@@ -14,6 +14,7 @@ import com.skydoves.sandwich.onSuccess
 import io.dock2dock.android.application.configuration.Dock2DockConfiguration
 import io.dock2dock.android.application.eventBus.Dock2DockEventBus
 import io.dock2dock.android.application.events.Dock2DockDefaultHandlingUnitChangedEvent
+import io.dock2dock.android.application.events.Dock2DockLpPrintCrossdockLabelChangedEvent
 import io.dock2dock.android.application.events.Dock2DockSalesOrderRetrievedEvent
 import io.dock2dock.android.application.events.LicensePlateSetToActiveEvent
 import io.dock2dock.android.application.models.commands.CreateLicensePlateRequest
@@ -28,7 +29,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
-class LicensePlateSettingsViewModel(val salesOrderNo: String): ViewModel() {
+class LicensePlateQuickCreateViewModel(val salesOrderNo: String): ViewModel() {
 
     private val publicApiClient = ApiService.getRetrofitClient<PublicApiClient>()
     var handlingUnits by mutableStateOf(listOf<CrossdockHandlingUnit>())
@@ -61,6 +62,7 @@ class LicensePlateSettingsViewModel(val salesOrderNo: String): ViewModel() {
     init {
         subscribeToSalesOrderRetrievedEvent()
         subscribeToHandlingUnitChangedEvent()
+        subscribeToLpPrintCrossdockLabelChangedEvent()
         getHandlingUnits()
         printCrossdockLabel = dock2dockConfiguration.getPrintCrossdockLabelSetting()
     }
@@ -159,6 +161,14 @@ class LicensePlateSettingsViewModel(val salesOrderNo: String): ViewModel() {
             Dock2DockEventBus.subscribe<Dock2DockDefaultHandlingUnitChangedEvent> {
                 selectedHandlingUnitText = it.handlingUnit.name
                 selectedHandlingUnitId = it.handlingUnit.id
+            }
+        }
+    }
+
+    private fun subscribeToLpPrintCrossdockLabelChangedEvent() {
+        viewModelScope.launch {
+            Dock2DockEventBus.subscribe<Dock2DockLpPrintCrossdockLabelChangedEvent> {
+                printCrossdockLabel = it.value
             }
         }
     }

--- a/crossdock/src/main/java/io/dock2dock/android/crossdock/viewModels/SettingsDialogViewModel.kt
+++ b/crossdock/src/main/java/io/dock2dock/android/crossdock/viewModels/SettingsDialogViewModel.kt
@@ -13,6 +13,8 @@ import com.skydoves.sandwich.onSuccess
 import io.dock2dock.android.application.configuration.Dock2DockConfiguration
 import io.dock2dock.android.application.eventBus.Dock2DockEventBus
 import io.dock2dock.android.application.events.Dock2DockDefaultHandlingUnitChangedEvent
+import io.dock2dock.android.application.events.Dock2DockLpPrintCrossdockLabelChangedEvent
+import io.dock2dock.android.application.events.Dock2DockShowLPQuickCreateViewChangedEvent
 import io.dock2dock.android.application.models.query.CrossdockHandlingUnit
 import io.dock2dock.android.application.models.query.Printer
 import io.dock2dock.android.networking.ApiService
@@ -31,18 +33,23 @@ internal class SettingsDialogViewModel: ViewModel() {
 
     var selectedPrinterText by mutableStateOf("")
 
+    var showLpQuickCreateView by mutableStateOf(false)
+    var lpPrintCrossdockLabel by mutableStateOf(false)
+
     private val dock2dockConfiguration = Dock2DockConfiguration.instance()
 
     fun load() {
         getHandlingUnits()
         getPrinters()
+        showLpQuickCreateView = dock2dockConfiguration.getShowLPQuickCreateViewSetting()
+        lpPrintCrossdockLabel = dock2dockConfiguration.getPrintCrossdockLabelSetting()
     }
 
     fun onHandlingUnitValueChanged(value: CrossdockHandlingUnit) {
         dock2dockConfiguration.updateDefaultHandlingUnit(value.id)
         selectedHandlingUnitText = value.name
 
-        var handlingUnitChangedEvent = Dock2DockDefaultHandlingUnitChangedEvent(value)
+        val handlingUnitChangedEvent = Dock2DockDefaultHandlingUnitChangedEvent(value)
 
         viewModelScope.launch {
             Dock2DockEventBus.publish(handlingUnitChangedEvent)
@@ -52,6 +59,28 @@ internal class SettingsDialogViewModel: ViewModel() {
     fun onPrinterValueChanged(value: Printer) {
         dock2dockConfiguration.updatePrinter(value.id)
         selectedPrinterText = value.name
+    }
+
+    fun onShowLpQuickCreateViewChanged(value: Boolean) {
+        dock2dockConfiguration.updateShowLPQuickCreateViewSetting(value)
+        showLpQuickCreateView = value
+
+        val eventChangedEvent = Dock2DockShowLPQuickCreateViewChangedEvent(value)
+
+        viewModelScope.launch {
+            Dock2DockEventBus.publish(eventChangedEvent)
+        }
+    }
+
+    fun onLpPrintCrossdockLabelChanged(value: Boolean) {
+        dock2dockConfiguration.updatePrintCrossdockLabelSetting(value)
+        lpPrintCrossdockLabel = value
+
+        val eventChangedEvent = Dock2DockLpPrintCrossdockLabelChangedEvent(value)
+
+        viewModelScope.launch {
+            Dock2DockEventBus.publish(eventChangedEvent)
+        }
     }
 
     private fun getHandlingUnits() {

--- a/ui/src/main/java/io/dock2dock/android/ui/components/Dock2DockSwitch.kt
+++ b/ui/src/main/java/io/dock2dock/android/ui/components/Dock2DockSwitch.kt
@@ -7,10 +7,10 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import io.dock2dock.android.ui.theme.PrimaryOrangeWeb
 import io.dock2dock.android.ui.theme.PrimaryPlatinum
-import io.dock2dock.android.ui.theme.PrimaryWhite
 
 @Composable
 fun Dock2DockSwitch(checked: Boolean,
@@ -22,9 +22,9 @@ fun Dock2DockSwitch(checked: Boolean,
         },
         colors = SwitchDefaults.colors(
             checkedThumbColor = PrimaryOrangeWeb,
-            checkedTrackColor = PrimaryPlatinum,
-            uncheckedThumbColor = PrimaryWhite,
-            uncheckedTrackColor = PrimaryPlatinum,
+            checkedTrackColor = Color.DarkGray,
+            uncheckedThumbColor = PrimaryPlatinum,
+            uncheckedTrackColor = Color.DarkGray,
         ),
     )
 }


### PR DESCRIPTION
* Added two settings to SettingsDialog - show Lp quick create view and print cross-dock label. Renamed LicensePlateSettingsScreen.kt to LicensePlateQuickCreateScreen.kt.

* updated version to 0.1.4

---------

Co-authored-by: Cameron Harris <>