### PR TITLE
Migrate Maven publishing to Central Portal compatibility endpoint

### DIFF
--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -22,6 +22,7 @@ jobs:
       - name: Build and upload artifacts
         run: ./gradlew publishReleasePublicationToSonatypeRepository --no-daemon --no-parallel
         env:
+          SNAPSHOT: true
           ORG_GRADLE_PROJECT_nexusUserName: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
           ORG_GRADLE_PROJECT_nexusPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
           ORG_GRADLE_PROJECT_sonatypeStagingProfileId: ${{ secrets.SONATYPE_STAGING_PROFILE_ID }}

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -22,9 +22,9 @@ jobs:
       - name: Build and upload artifacts
         run: ./gradlew publishReleasePublicationToSonatypeRepository --no-daemon --no-parallel
         env:
-          NEXUS_USERNAME: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
-          NEXUS_PASSWORD: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
-          SONATYPE_STAGING_PROFILE_ID: ${{ secrets.SONATYPE_STAGING_PROFILE_ID }}
-          signing.keyId: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEYID }}
-          signing.key: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEY }}
-          signing.password: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD }}
+          ORG_GRADLE_PROJECT_nexusUserName: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
+          ORG_GRADLE_PROJECT_nexusPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
+          ORG_GRADLE_PROJECT_sonatypeStagingProfileId: ${{ secrets.SONATYPE_STAGING_PROFILE_ID }}
+          ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEYID }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD }}

--- a/deploy/deploy-root.gradle
+++ b/deploy/deploy-root.gradle
@@ -41,8 +41,8 @@ nexusPublishing {
             stagingProfileId = sonatypeStagingProfileId
             username = ossrhUsername
             password = ossrhPassword
-            nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
-            snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
         }
     }
 

--- a/deploy/deploy-root.gradle
+++ b/deploy/deploy-root.gradle
@@ -38,7 +38,11 @@ nexusPublishing {
 
     repositories {
         sonatype {
-            stagingProfileId = sonatypeStagingProfileId
+            // Only set stagingProfileId when provided: assigning an empty string still
+            // marks the Property as present, which skips the plugin's auto-detection.
+            if (sonatypeStagingProfileId) {
+                stagingProfileId = sonatypeStagingProfileId
+            }
             username = ossrhUsername
             password = ossrhPassword
             nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))


### PR DESCRIPTION
## Summary
- Point `nexusUrl`/`snapshotRepositoryUrl` at the new Central Portal compatibility endpoints (`s01.oss.sonatype.org` is being retired)
- Fix `release-snapshot.yml` env var names to `ORG_GRADLE_PROJECT_*` so Gradle actually picks up the nexus/signing credentials

## Test plan
- [ ] Regenerate OSSRH token at central.sonatype.com/usertoken and update `SONATYPE_NEXUS_USERNAME`/`SONATYPE_NEXUS_PASSWORD` secrets
- [ ] Confirm `io.dock2dock` namespace is attached under central.sonatype.com/publishing/namespaces
- [ ] Run `release-snapshot.yml` via workflow_dispatch first (leave `SONATYPE_STAGING_PROFILE_ID` unset to test auto-detection)
- [ ] Run `release.yml` for a real release once snapshot publish succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)