### PR TITLE
Merge release/v0.2.13 into main

### DIFF
--- a/application/src/main/java/io/dock2dock/android/application/models/query/ConsignmentHeaderItem.kt
+++ b/application/src/main/java/io/dock2dock/android/application/models/query/ConsignmentHeaderItem.kt
@@ -13,7 +13,8 @@ data class ConsignmentHeaderItem(
     val height: Double,
     val quantity: Double,
     val pallets: Int,
-    val locked: Boolean
+    val locked: Boolean,
+    val isPallet: Boolean
 ) {
     val description: String
         get() {
@@ -23,7 +24,4 @@ data class ConsignmentHeaderItem(
                 "$consignmentProductName · Qty: ${"%.0f".format(quantity)} · Wgt: $weight"
             }
         }
-
-    val isPallet: Boolean
-        get() = consignmentProductTypeId == "pallet"
 }

--- a/buildSrc/src/main/java/io/dock2dock/android/Configuration.kt
+++ b/buildSrc/src/main/java/io/dock2dock/android/Configuration.kt
@@ -4,7 +4,7 @@ object Configuration {
     const val minSdk = 23
     const val majorVersion = 0
     const val minorVersion = 2
-    const val patchVersion = 12
+    const val patchVersion = 13
     const val versionName = "$majorVersion.$minorVersion.$patchVersion"
     const val snapshotVersionName = "$majorVersion.$minorVersion.${patchVersion + 1}-SNAPSHOT"
     const val artifactGroup = "io.dock2dock"

--- a/example/src/main/java/io/dock2dock/example/components/ConsignmentHeaderPageScreen.kt
+++ b/example/src/main/java/io/dock2dock/example/components/ConsignmentHeaderPageScreen.kt
@@ -19,7 +19,7 @@ import io.dock2dock.android.ui.components.DefaultTopAppBar
 fun ConsignmentHeaderPageScreen(
     navController: NavController
 ) {
-    val salesOrderNumber = "FC1008"
+    val salesOrderNumber = "109316"
 
     fun navigateToPrintShippingLabels() {
         navController.navigate("consignmentHeader/$salesOrderNumber/printShippingLabels")


### PR DESCRIPTION
## Summary
- `release/v0.2.13` (PR #49, "isPallet" feature) was tagged and published but never merged back into `main` — `main` was 1 patch version behind the actual last release.
- Merges `release/v0.2.13` into `main` so `Configuration.kt` and `ConsignmentHeaderItem.kt` are back in sync with what's actually been released.

## Test plan
- [ ] Confirm `buildSrc/.../Configuration.kt` patchVersion reads 13 after merge
- [ ] Confirm no behavior regression in `ConsignmentHeaderItem` isPallet handling