### PR TITLE
Auto-tag and publish a snapshot on every merge to main

### DIFF
--- a/.github/workflows/generate-tag.yml
+++ b/.github/workflows/generate-tag.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Compute next version
         id: semver
-        uses: paulhatch/semantic-version@v5
+        uses: paulhatch/semantic-version@v5.4.0
         with:
           tag_prefix: "v"
           major_pattern: "(MAJOR)"

--- a/.github/workflows/generate-tag.yml
+++ b/.github/workflows/generate-tag.yml
@@ -1,0 +1,41 @@
+name: Generate tag
+
+# Runs on every merge to main. paulhatch/semantic-version computes the next
+# version from git tag/commit history (patch bumps by default; include
+# "(MINOR)" or "(MAJOR)" in a commit message to bump those instead) and the
+# commit is tagged accordingly. Pushing the tag triggers release-snapshot.yml
+# separately, which publishes it as a SNAPSHOT to Maven.
+#
+# Nothing is committed back to main - only a tag is pushed - so this doesn't
+# run into the branch protection rule requiring PR review on main.
+on:
+  push:
+    branches: [ main ]
+
+permissions:
+  contents: write
+
+jobs:
+  generate-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Compute next version
+        id: semver
+        uses: paulhatch/semantic-version@v5
+        with:
+          tag_prefix: "v"
+          major_pattern: "(MAJOR)"
+          minor_pattern: "(MINOR)"
+          version_format: "${major}.${minor}.${patch}"
+          bump_each_commit: false
+
+      - name: Create and push tag
+        run: |
+          set -euo pipefail
+          git tag "${{ steps.semver.outputs.version_tag }}"
+          git push origin "${{ steps.semver.outputs.version_tag }}"

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -1,28 +1,47 @@
 name: Publish SNAPSHOT to Maven Central
 
 on:
+  push:
+    tags:
+      - 'v*.*.*'
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish, without the -SNAPSHOT suffix (e.g. 0.2.14). Defaults to the pushed tag, or Configuration.kt patch+1 if run manually with no tag.'
+        required: false
+        type: string
 
 jobs:
   publish-snapshot:
     runs-on: ubuntu-latest
     steps:
       - name: Clone Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Set up JDK 18
-        uses: actions/setup-java@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
         with:
-          java-version: '18'
-          distribution: 'adopt'
+          distribution: 'zulu'
+          java-version: 17
 
       - name: Clean build directory
         run: ./gradlew clean
 
+      - name: Resolve version
+        id: resolve_version
+        run: |
+          set -euo pipefail
+          VERSION="${{ inputs.version }}"
+          if [ -z "$VERSION" ] && [ "${{ github.ref_type }}" = "tag" ]; then
+            VERSION="${GITHUB_REF_NAME#v}"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
       - name: Build and upload artifacts
-        run: ./gradlew publishReleasePublicationToSonatypeRepository --no-daemon --no-parallel
+        run: ./gradlew publishReleasePublicationToSonatypeRepository --no-daemon --no-parallel --stacktrace
         env:
           SNAPSHOT: true
+          VERSION: ${{ steps.resolve_version.outputs.version && format('{0}-SNAPSHOT', steps.resolve_version.outputs.version) || '' }}
           ORG_GRADLE_PROJECT_nexusUserName: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
           ORG_GRADLE_PROJECT_nexusPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
           ORG_GRADLE_PROJECT_sonatypeStagingProfileId: ${{ secrets.SONATYPE_STAGING_PROFILE_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,11 @@ on:
   release:
     types: [ released ]
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g. 0.2.14). Defaults to Configuration.kt versionName.'
+        required: false
+        type: string
 
 jobs:
   publish:
@@ -21,9 +26,22 @@ jobs:
       - name: Clean build directory
         run: ./gradlew clean
 
+      - name: Resolve version
+        id: resolve_version
+        run: |
+          # GitHub Releases are cut from tags created by generate-tag.yml
+          # (format vX.Y.Z), so the tag itself is the source of truth for the version.
+          VERSION="${{ inputs.version }}"
+          if [ -z "$VERSION" ]; then
+            VERSION="${{ github.event.release.tag_name }}"
+            VERSION="${VERSION#v}"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
       - name: Build and upload artifacts
         run: ./gradlew publishReleasePublicationToSonatypeRepository --no-daemon --no-parallel --stacktrace
         env:
+          VERSION: ${{ steps.resolve_version.outputs.version }}
           ORG_GRADLE_PROJECT_nexusUserName: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
           ORG_GRADLE_PROJECT_nexusPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
           ORG_GRADLE_PROJECT_sonatypeStagingProfileId: ${{ secrets.SONATYPE_STAGING_PROFILE_ID }}

--- a/deploy/deploy-root.gradle
+++ b/deploy/deploy-root.gradle
@@ -27,7 +27,14 @@ if (secretPropsFile.exists()) {
     ext["snapshot"] = System.getenv('SNAPSHOT')
 }
 
-if (snapshot) {
+// CI publishes tag-derived versions (see .github/workflows/generate-tag.yml,
+// release-snapshot.yml and release.yml) rather than relying on Configuration.kt
+// being bumped by hand. Configuration.versionName/snapshotVersionName remain
+// the fallback for local/manual runs.
+def versionOverride = System.getenv('VERSION')
+if (versionOverride) {
+    ext["rootVersionName"] = versionOverride
+} else if (snapshot) {
     ext["rootVersionName"] = Configuration.snapshotVersionName
 } else {
     ext["rootVersionName"] = Configuration.versionName


### PR DESCRIPTION
## Summary
- `generate-tag.yml` (new): on every push to `main`, computes the next version from git tag/commit history using `paulhatch/semantic-version` and pushes a `vX.Y.Z` tag. Patch bumps by default; include `(MINOR)` or `(MAJOR)` in a commit message to bump those instead. Only a tag is pushed (nothing committed to `main`), so this doesn't hit the branch-protection rule requiring a PR review on `main`.
- `release-snapshot.yml`: now also triggers on that tag push (`push: tags: v*.*.*`) and publishes it as a `-SNAPSHOT`, resolving the version from the tag itself instead of `Configuration.kt`. Also updated to `actions/checkout@v4` / JDK 17 zulu to match `release.yml`.
- `release.yml` (full releases, still manually triggered by publishing a GitHub Release against one of the auto-generated tags): resolves the version from the release's `tag_name` the same way.
- `deploy-root.gradle`: honors a `VERSION` env var override ahead of `Configuration.kt`. `Configuration.versionName` / `snapshotVersionName` remain as the fallback for local/manual runs with no override.

Net effect: nobody needs to hand-edit `Configuration.kt`'s `patchVersion` anymore, and every merge to `main` produces a fresh, installable snapshot artifact automatically.

Depends on / should land after #51 (merges the missing `release/v0.2.13` into `main`) so version history isn't discontinuous, but doesn't strictly require it.

## Test plan
- [ ] Merge to a test branch/fork first, or watch the first real merge to `main` closely: confirm `generate-tag.yml` computes the expected next patch tag and pushes it
- [ ] Confirm `release-snapshot.yml` fires off that tag push and the Sonatype snapshot repo receives the new `-SNAPSHOT` version
- [ ] Manually trigger `release-snapshot.yml` via `workflow_dispatch` with no `version` input and confirm it still falls back to `Configuration.kt`'s `patch+1`
- [ ] Next time an actual GitHub Release is cut, confirm `release.yml` publishes the non-SNAPSHOT version matching the release's tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)