### PR TITLE
Add configurable barcode types and reader config for Honeywell scanner

### DIFF
--- a/application/src/main/java/io/dock2dock/android/application/events/Dock2DockBarcodeScannedEvent.kt
+++ b/application/src/main/java/io/dock2dock/android/application/events/Dock2DockBarcodeScannedEvent.kt
@@ -1,5 +1,6 @@
 package io.dock2dock.android.application.events
 
 data class Dock2DockBarcodeScannedEvent(
-    val barcode: String
+    val barcode: String,
+    val barcodeType: String? = null
 )

--- a/application/src/main/java/io/dock2dock/android/application/events/Dock2DockBarcodeScannedEvent.kt
+++ b/application/src/main/java/io/dock2dock/android/application/events/Dock2DockBarcodeScannedEvent.kt
@@ -2,5 +2,5 @@ package io.dock2dock.android.application.events
 
 data class Dock2DockBarcodeScannedEvent(
     val barcode: String,
-    val barcodeType: String? = null
+    val barcodeType: String
 )

--- a/barcodeScanner/src/main/java/io/dock2dock/android/barcodeScanner/models/BarcodeReaderConfig.kt
+++ b/barcodeScanner/src/main/java/io/dock2dock/android/barcodeScanner/models/BarcodeReaderConfig.kt
@@ -1,0 +1,17 @@
+package io.dock2dock.android.barcodeScanner.models
+
+data class BarcodeReaderConfig(
+    val code39Enabled: Boolean = true,
+    val code39MaximumLength: Int = 10,
+    val code128Enabled: Boolean = true,
+    val gs1_128Enabled: Boolean = true,
+    val dataMatrixEnabled: Boolean = true,
+    val upcAEnabled: Boolean = true,
+    val ean13Enabled: Boolean = true,
+    val aztecEnabled: Boolean = false,
+    val codabarEnabled: Boolean = false,
+    val interleaved25Enabled: Boolean = false,
+    val pdf417Enabled: Boolean = false,
+    val centerDecodeEnabled: Boolean = true,
+    val badReadNotificationEnabled: Boolean = true
+)

--- a/barcodeScanner/src/main/java/io/dock2dock/android/barcodeScanner/models/BarcodeScannedEvent.kt
+++ b/barcodeScanner/src/main/java/io/dock2dock/android/barcodeScanner/models/BarcodeScannedEvent.kt
@@ -1,0 +1,6 @@
+package io.dock2dock.android.barcodeScanner.models
+
+data class BarcodeScannedEvent(
+    val barcode: String,
+    val barcodeType: BarcodeType
+)

--- a/barcodeScanner/src/main/java/io/dock2dock/android/barcodeScanner/models/BarcodeType.kt
+++ b/barcodeScanner/src/main/java/io/dock2dock/android/barcodeScanner/models/BarcodeType.kt
@@ -1,0 +1,14 @@
+package io.dock2dock.android.barcodeScanner.models
+
+enum class BarcodeType {
+    CODE39,
+    CODE128,
+    UPC_A,
+    EAN_13,
+    CODABAR,
+    CODE93,
+    QR,
+    DATAMATRIX,
+    GS1_DATABAR,
+    UNKNOWN
+}

--- a/barcodeScanner/src/main/java/io/dock2dock/android/barcodeScanner/models/HoneywellBarcodeReader.kt
+++ b/barcodeScanner/src/main/java/io/dock2dock/android/barcodeScanner/models/HoneywellBarcodeReader.kt
@@ -22,7 +22,7 @@ interface IBarcodeReader {
 }
 
 interface IBarcodeReaderListener {
-    fun onBarcodeScanned(barcode: String)
+    fun onBarcodeScanned(event: BarcodeScannedEvent)
     fun onBarcodeFailure()
 }
 
@@ -30,7 +30,10 @@ interface IBarcodeTriggerListener {
     fun onBarcodeTrigger()
 }
 
-class HoneywellBarcodeReader(private val context: Context): IBarcodeReader, DefaultLifecycleObserver {
+class HoneywellBarcodeReader(
+    private val context: Context,
+    private val config: BarcodeReaderConfig = BarcodeReaderConfig()
+): IBarcodeReader, DefaultLifecycleObserver {
 
     private var reader: BarcodeReader? = null
     private var barcodeReaderListener: BarcodeReader.BarcodeListener? = null
@@ -52,25 +55,23 @@ class HoneywellBarcodeReader(private val context: Context): IBarcodeReader, Defa
                     BarcodeReader.TRIGGER_CONTROL_MODE_CLIENT_CONTROL
                 )
 
-                reader?.setProperty(BarcodeReader.PROPERTY_CODE_39_ENABLED, true)
-                reader?.setProperty(BarcodeReader.PROPERTY_DATAMATRIX_ENABLED, true)
-                reader?.setProperty(BarcodeReader.PROPERTY_CODE_128_ENABLED, true)
-                reader?.setProperty(BarcodeReader.PROPERTY_GS1_128_ENABLED, true)
-                reader?.setProperty(BarcodeReader.PROPERTY_CODE_39_ENABLED, true)
-                reader?.setProperty(BarcodeReader.PROPERTY_DATAMATRIX_ENABLED, true)
-                reader?.setProperty(BarcodeReader.PROPERTY_UPC_A_ENABLE, true)
-                reader?.setProperty(BarcodeReader.PROPERTY_EAN_13_ENABLED, true)
-                reader?.setProperty(BarcodeReader.PROPERTY_AZTEC_ENABLED, false)
-                reader?.setProperty(BarcodeReader.PROPERTY_CODABAR_ENABLED, false)
-                reader?.setProperty(BarcodeReader.PROPERTY_INTERLEAVED_25_ENABLED, false)
-                reader?.setProperty(BarcodeReader.PROPERTY_PDF_417_ENABLED, false)
+                reader?.setProperty(BarcodeReader.PROPERTY_CODE_39_ENABLED, config.code39Enabled)
+                reader?.setProperty(BarcodeReader.PROPERTY_DATAMATRIX_ENABLED, config.dataMatrixEnabled)
+                reader?.setProperty(BarcodeReader.PROPERTY_CODE_128_ENABLED, config.code128Enabled)
+                reader?.setProperty(BarcodeReader.PROPERTY_GS1_128_ENABLED, config.gs1_128Enabled)
+                reader?.setProperty(BarcodeReader.PROPERTY_UPC_A_ENABLE, config.upcAEnabled)
+                reader?.setProperty(BarcodeReader.PROPERTY_EAN_13_ENABLED, config.ean13Enabled)
+                reader?.setProperty(BarcodeReader.PROPERTY_AZTEC_ENABLED, config.aztecEnabled)
+                reader?.setProperty(BarcodeReader.PROPERTY_CODABAR_ENABLED, config.codabarEnabled)
+                reader?.setProperty(BarcodeReader.PROPERTY_INTERLEAVED_25_ENABLED, config.interleaved25Enabled)
+                reader?.setProperty(BarcodeReader.PROPERTY_PDF_417_ENABLED, config.pdf417Enabled)
 
                 //Set Max Code 39 barcode length
-                reader?.setProperty(BarcodeReader.PROPERTY_CODE_39_MAXIMUM_LENGTH, 10)
+                reader?.setProperty(BarcodeReader.PROPERTY_CODE_39_MAXIMUM_LENGTH, config.code39MaximumLength)
                 // Turn on center decoding
-                reader?.setProperty(BarcodeReader.PROPERTY_CENTER_DECODE, true)
+                reader?.setProperty(BarcodeReader.PROPERTY_CENTER_DECODE, config.centerDecodeEnabled)
                 // Enable bad read response
-                reader?.setProperty(BarcodeReader.PROPERTY_NOTIFICATION_BAD_READ_ENABLED, true)
+                reader?.setProperty(BarcodeReader.PROPERTY_NOTIFICATION_BAD_READ_ENABLED, config.badReadNotificationEnabled)
 
                 barcodeReaderListener?.let {
                     reader?.addBarcodeListener(it)
@@ -92,7 +93,9 @@ class HoneywellBarcodeReader(private val context: Context): IBarcodeReader, Defa
                 try {
                     reader?.softwareTrigger(false)
                     val data = event.barcodeData
-                    listener.onBarcodeScanned(data)
+                    val type = event.codeId
+                    val barcodeType = HoneywellBarcodeType.getBarcodeType(type)
+                    listener.onBarcodeScanned(BarcodeScannedEvent(data, barcodeType))
 
                 } catch (e: ScannerNotClaimedException) {
                     e.printStackTrace()

--- a/barcodeScanner/src/main/java/io/dock2dock/android/barcodeScanner/models/HoneywellBarcodeType.kt
+++ b/barcodeScanner/src/main/java/io/dock2dock/android/barcodeScanner/models/HoneywellBarcodeType.kt
@@ -1,33 +1,18 @@
 package io.dock2dock.android.barcodeScanner.models
 
-import com.google.gson.annotations.SerializedName
-
-enum class HoneywellBarcodeType(val codeId: String) {
-    @SerializedName("0")
-    EAN_13("d") {
-        override val id: Int = 0
-    },
-    @SerializedName("1")
-    GS1_128("I") {
-        override val id: Int = 1
-    },
-    @SerializedName("2")
-    QR("s") {
-        override val id: Int = 2
-    },
-    @SerializedName("3")
-    CODE39("b") {
-        override val id: Int = 3
-    },
-    @SerializedName("4")
-    CODE128("j") {
-        override val id: Int = 4
-    };
-
-    abstract val id: Int
+enum class HoneywellBarcodeType(val codeId: String, val barcodeType: BarcodeType) {
+    CODE39("b", BarcodeType.CODE39),
+    CODE128("j", BarcodeType.CODE128),
+    UPC_A("c", BarcodeType.UPC_A),
+    EAN_13("d", BarcodeType.EAN_13),
+    CODABAR("a", BarcodeType.CODABAR),
+    CODE93("i", BarcodeType.CODE93),
+    QR("s", BarcodeType.QR),
+    DATAMATRIX("w", BarcodeType.DATAMATRIX),
+    GS1_DATABAR("y", BarcodeType.GS1_DATABAR);
 
     companion object {
-        fun getBarcodeTypeByName(codeId: String) = values().firstOrNull { it.codeId == codeId }
+        fun getBarcodeType(codeId: String): BarcodeType =
+            values().firstOrNull { it.codeId == codeId }?.barcodeType ?: BarcodeType.UNKNOWN
     }
 }
-

--- a/build-configuration/android-base-application.gradle
+++ b/build-configuration/android-base-application.gradle
@@ -32,12 +32,12 @@ android {
     if (secretPropsFile.exists()) {
         def localProperties = new Properties()
         localProperties.load(new FileInputStream(rootProject.file("local.properties")))
-        apiKey = localProperties['dock2dock_apiKey']
+        apiKey = localProperties['dock2dock_apiKey'] ?: ""
     }
 
     buildTypes {
         debug {
-            buildConfigField("String", "Dock2Dock_ApiKey", apiKey)
+            buildConfigField("String", "Dock2Dock_ApiKey", "\"${apiKey}\"")
         }
         release {
             minifyEnabled false

--- a/example/src/main/java/io/dock2dock/example/activities/MainActivity.kt
+++ b/example/src/main/java/io/dock2dock/example/activities/MainActivity.kt
@@ -14,6 +14,7 @@ import io.dock2dock.android.application.eventBus.Dock2DockEventBus
 import io.dock2dock.android.application.events.Dock2DockBarcodeFailedEvent
 import io.dock2dock.android.application.events.Dock2DockBarcodeScannedEvent
 import io.dock2dock.android.barcodeScanner.models.AndroidOsBrand
+import io.dock2dock.android.barcodeScanner.models.BarcodeScannedEvent
 import io.dock2dock.android.barcodeScanner.models.HoneywellBarcodeReader
 import io.dock2dock.android.barcodeScanner.models.IBarcodeReader
 import io.dock2dock.android.barcodeScanner.models.IBarcodeReaderListener
@@ -59,11 +60,11 @@ class MainActivity : ComponentActivity(),
         }
     }
 
-    override fun onBarcodeScanned(barcode: String) {
+    override fun onBarcodeScanned(event: BarcodeScannedEvent) {
         runBlocking {
             withContext(Dispatchers.IO) {
-                val event = Dock2DockBarcodeScannedEvent(barcode)
-                Dock2DockEventBus.publish(event)
+                val scannedEvent = Dock2DockBarcodeScannedEvent(event.barcode, event.barcodeType.name)
+                Dock2DockEventBus.publish(scannedEvent)
             }
         }
     }


### PR DESCRIPTION
## Summary
- Introduce device-agnostic `BarcodeType` enum and `BarcodeScannedEvent` model, replacing the raw barcode string in `IBarcodeReaderListener.onBarcodeScanned`
- Add `BarcodeReaderConfig` so Honeywell symbology enable/disable flags (Code39, Code128, GS1-128, DataMatrix, UPC-A, EAN-13, Aztec, Codabar, Interleaved 2 of 5, PDF417) and a few reader properties are configurable instead of hardcoded, and dedupe the previously duplicated property sets
- Expand `HoneywellBarcodeType` to map more Honeywell code IDs to the new `BarcodeType`, replacing the old ordinal/`SerializedName`-based enum
- Propagate the decoded `barcodeType` through to `Dock2DockBarcodeScannedEvent`
- Fix debug `Dock2Dock_ApiKey` BuildConfig field to be quoted and default to empty string when unset in `local.properties`

## Test plan
- [ ] Build the `example` app and confirm it compiles against the updated `IBarcodeReaderListener` interface
- [ ] Scan a few different barcode symbologies on a Honeywell device and confirm `barcodeType` is populated correctly
- [ ] Confirm debug build still picks up `dock2dock_apiKey` from `local.properties` when present

🤖 Generated with [Claude Code](https://claude.com/claude-code)