### PR TITLE
Explicitly dispatch release-snapshot.yml after tagging

### DIFF
--- a/.github/workflows/generate-tag.yml
+++ b/.github/workflows/generate-tag.yml
@@ -3,8 +3,12 @@ name: Generate tag
 # Runs on every merge to main. paulhatch/semantic-version computes the next
 # version from git tag/commit history (patch bumps by default; include
 # "(MINOR)" or "(MAJOR)" in a commit message to bump those instead) and the
-# commit is tagged accordingly. Pushing the tag triggers release-snapshot.yml
-# separately, which publishes it as a SNAPSHOT to Maven.
+# commit is tagged accordingly. release-snapshot.yml is then explicitly
+# dispatched to publish the tag as a SNAPSHOT to Maven.
+#
+# The tag push can't rely on release-snapshot.yml's own `push: tags` trigger
+# to fire it: GitHub doesn't chain workflow runs off events produced by the
+# default GITHUB_TOKEN, to avoid infinite trigger loops.
 #
 # Nothing is committed back to main - only a tag is pushed - so this doesn't
 # run into the branch protection rule requiring PR review on main.
@@ -14,6 +18,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   generate-tag:
@@ -39,3 +44,12 @@ jobs:
           set -euo pipefail
           git tag "${{ steps.semver.outputs.version_tag }}"
           git push origin "${{ steps.semver.outputs.version_tag }}"
+
+      - name: Trigger snapshot release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh workflow run release-snapshot.yml \
+            --ref "${{ steps.semver.outputs.version_tag }}" \
+            -f version="${{ steps.semver.outputs.version }}"


### PR DESCRIPTION
Tags pushed with the default GITHUB_TOKEN don't fire other workflows' push triggers (GitHub blocks this to prevent infinite trigger loops), so release-snapshot.yml's `push: tags` trigger never ran after generate-tag.yml pushed a new tag. Dispatch it explicitly via the API instead.