### PR TITLE
Close and release Sonatype staging repo after publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,3 +48,13 @@ jobs:
           ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEYID }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD }}
+
+      # publishReleasePublicationToSonatypeRepository only stages the artifacts;
+      # Maven Central won't serve them until the staging repo is closed and released.
+      - name: Close and release staging repository
+        run: ./gradlew closeAndReleaseSonatypeStagingRepository --no-daemon --no-parallel --stacktrace
+        env:
+          VERSION: ${{ steps.resolve_version.outputs.version }}
+          ORG_GRADLE_PROJECT_nexusUserName: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
+          ORG_GRADLE_PROJECT_nexusPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
+          ORG_GRADLE_PROJECT_sonatypeStagingProfileId: ${{ secrets.SONATYPE_STAGING_PROFILE_ID }}


### PR DESCRIPTION
## Summary
- `publishReleasePublicationToSonatypeRepository` only uploads artifacts to an open Sonatype staging repository — it doesn't close/release it, so nothing appeared in the Central Portal deployments view and artifacts never reached Maven Central.
- Chain `closeAndReleaseSonatypeStagingRepository` after the upload step so `release.yml` fully publishes releases without a manual step.

## Test plan
- [ ] Trigger `release.yml` via `workflow_dispatch` for a version and confirm the new "Close and release staging repository" step succeeds
- [ ] Verify the version appears on Maven Central (search.maven.org) after the run