### PR TITLE
Fix version resolution for manual release.yml dispatches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to publish (e.g. 0.2.14). Defaults to Configuration.kt versionName.'
+        description: 'Version to publish (e.g. 0.2.14). Defaults to the release tag, or the dispatched tag ref if run manually against a tag.'
         required: false
         type: string
 
@@ -29,12 +29,25 @@ jobs:
       - name: Resolve version
         id: resolve_version
         run: |
+          set -euo pipefail
           # GitHub Releases are cut from tags created by generate-tag.yml
           # (format vX.Y.Z), so the tag itself is the source of truth for the version.
           VERSION="${{ inputs.version }}"
           if [ -z "$VERSION" ]; then
             VERSION="${{ github.event.release.tag_name }}"
-            VERSION="${VERSION#v}"
+          fi
+          # github.event.release.tag_name is only populated for `release` events.
+          # workflow_dispatch runs against a tag ref instead, so fall back to that.
+          if [ -z "$VERSION" ] && [ "${{ github.ref_type }}" = "tag" ]; then
+            VERSION="${GITHUB_REF_NAME}"
+          fi
+          VERSION="${VERSION#v}"
+          if [ -z "$VERSION" ]; then
+            # Refuse to fall back to Configuration.kt's versionName: that silently
+            # rebuilds an already-published version and Sonatype rejects the
+            # duplicate deployment as "already exists".
+            echo "::error::Could not resolve a version to publish (no version input, no release tag, and not run against a tag ref)." >&2
+            exit 1
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary
- `release.yml`'s "Resolve version" step only fell back to `github.event.release.tag_name`, which is empty for `workflow_dispatch` runs.
- Dispatching manually without the `version` input silently resolved `VERSION` to empty, so `deploy-root.gradle` fell back to `Configuration.kt`'s hardcoded `versionName` (`0.2.13`) — a version already published to Maven Central.
- Sonatype rejected the duplicate deployment when closing the staging repo (`Component with package url '...@0.2.13?type=aar' already exists`), which is what caused the `v0.2.18` run to fail.
- Fix: fall back to the dispatched tag ref (mirroring `release-snapshot.yml`'s existing logic) and fail the job outright if no version can be resolved, instead of silently building a stale version.

## Test plan
- [ ] Dispatch `release.yml` against tag `v0.2.18` (or later) without the `version` input and confirm it resolves the version from the tag ref and doesn't collide with an existing Maven Central version
- [ ] Dispatch `release.yml` with no tag ref and no `version` input and confirm the job fails fast with a clear error instead of silently using `Configuration.kt`'s version