### PR TITLE
Fix Honeywell AIDC classes missing from published barcodeScanner artifact

### DIFF
--- a/barcodeScanner/build.gradle
+++ b/barcodeScanner/build.gradle
@@ -14,8 +14,7 @@ dependencies {
     implementation(Dependencies.androidxLifecycleRunTimeKtx)
     implementation(Dependencies.androidxLifecycleCommon)
 
-    debugImplementation files('libs/DataCollection.aar')
-    compileOnly files('libs/DataCollection.aar')
+    implementation files('libs/DataCollection.aar')
 
     testImplementation(Dependencies.jUnit)
     androidTestImplementation(Dependencies.androidxTestJunit)


### PR DESCRIPTION
## Summary
- `compileOnly files('libs/DataCollection.aar')` made Honeywell's AIDC SDK available at compile time but never packaged its classes into the published `io.dock2dock:barcodeScanner` artifact — `debugImplementation` only affected barcodeScanner's own debug build, not what gets published via maven-publish.
- Any app depending on the published artifact (dev, sandbox, prod, debug or release) was missing `com/honeywell/aidc/*` classes and crashed as soon as `HoneywellBarcodeReader`/`AidcManager` was touched on a Honeywell device (e.g. CT45).
- Replaced the split `debugImplementation`/`compileOnly` with a single `implementation files('libs/DataCollection.aar')` so the classes ship in the published artifact.

## Test plan
- [ ] Publish a snapshot/local build of `barcodeScanner` and confirm the resulting jar/aar contains `com/honeywell/aidc/*` classes
- [ ] Consume the new artifact from a downstream app and verify `initialiseBarcodeReader()` no longer crashes on a Honeywell CT45
- [ ] Cut a new release (tag-driven via `release.yml`) and bump the consumer's version pin once verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)