### PR TITLE
Fix client-trigger scanning + add good-read notification toggle

### DIFF
--- a/barcodeScanner/src/main/java/io/dock2dock/android/barcodeScanner/models/BarcodeReaderConfig.kt
+++ b/barcodeScanner/src/main/java/io/dock2dock/android/barcodeScanner/models/BarcodeReaderConfig.kt
@@ -13,5 +13,6 @@ data class BarcodeReaderConfig(
     val interleaved25Enabled: Boolean = false,
     val pdf417Enabled: Boolean = false,
     val centerDecodeEnabled: Boolean = true,
-    val badReadNotificationEnabled: Boolean = true
+    val badReadNotificationEnabled: Boolean = true,
+    val goodReadNotificationEnabled: Boolean = true
 )

--- a/barcodeScanner/src/main/java/io/dock2dock/android/barcodeScanner/models/HoneywellBarcodeReader.kt
+++ b/barcodeScanner/src/main/java/io/dock2dock/android/barcodeScanner/models/HoneywellBarcodeReader.kt
@@ -55,6 +55,8 @@ class HoneywellBarcodeReader(
                     BarcodeReader.TRIGGER_CONTROL_MODE_CLIENT_CONTROL
                 )
 
+                reader?.setProperty(BarcodeReader.PROPERTY_NOTIFICATION_GOOD_READ_ENABLED, config.goodReadNotificationEnabled)
+
                 reader?.setProperty(BarcodeReader.PROPERTY_CODE_39_ENABLED, config.code39Enabled)
                 reader?.setProperty(BarcodeReader.PROPERTY_DATAMATRIX_ENABLED, config.dataMatrixEnabled)
                 reader?.setProperty(BarcodeReader.PROPERTY_CODE_128_ENABLED, config.code128Enabled)

--- a/barcodeScanner/src/main/java/io/dock2dock/android/barcodeScanner/models/HoneywellBarcodeReader.kt
+++ b/barcodeScanner/src/main/java/io/dock2dock/android/barcodeScanner/models/HoneywellBarcodeReader.kt
@@ -91,7 +91,12 @@ class HoneywellBarcodeReader(
         barcodeReaderListener = object : BarcodeReader.BarcodeListener {
             override fun onBarcodeEvent(event: BarcodeReadEvent) {
                 try {
-                    reader?.softwareTrigger(false)
+                    // Trigger arm/disarm is owned entirely by the TriggerListener below,
+                    // reacting to the physical trigger's real press/release state - this
+                    // matches Honeywell's documented client-trigger-control sample, which
+                    // calls no reader method here. Calling softwareTrigger()/decode() from
+                    // this handler injects a second, out-of-band trigger transition that
+                    // desyncs hardware/software trigger state and breaks later scans.
                     val data = event.barcodeData
                     val type = event.codeId
                     val barcodeType = HoneywellSymbology.fromCodeId(type)


### PR DESCRIPTION
## Summary
- After a successful scan, every subsequent scan returned `onFailureEvent`. Root cause: `onBarcodeEvent` called `reader.softwareTrigger(false)`, which sends a synthetic trigger up/down action over the *same* channel as the physical trigger, desyncing hardware/software trigger state.
- First fix attempt (`reader.decode(false)`) made it worse — every scan including the first started failing, since stopping decode synchronously inside the event handler races the in-flight read notification.
- Actual fix: call **no** reader method from `onBarcodeEvent` at all, matching Honeywell's documented client-trigger-control sample exactly. Trigger arm/disarm (`aim()`/`light()`/`decode()`) is owned entirely by the `TriggerListener`, which already reacts to the physical trigger's real press/release state — no separate signal is needed on read success.
- Also folds in #62: adds `BarcodeReaderConfig.goodReadNotificationEnabled` (defaults to `true`), wired to `BarcodeReader.PROPERTY_NOTIFICATION_GOOD_READ_ENABLED`, mirroring the existing `badReadNotificationEnabled` toggle. Previously the good-read beep was never explicitly set and stayed at the device's default with no way to disable it.

## Test plan
- [x] `./gradlew :barcodeScanner:compileDebugKotlin` passes
- [ ] On a Honeywell device, confirm multiple consecutive scans (not just the first) resolve to `onBarcodeScanned`
- [ ] Confirm the good-read beep can be toggled off via `BarcodeReaderConfig(goodReadNotificationEnabled = false)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)