### PR TITLE
Add toggle for Honeywell good-read notification sound

### DIFF
--- a/barcodeScanner/src/main/java/io/dock2dock/android/barcodeScanner/models/BarcodeReaderConfig.kt
+++ b/barcodeScanner/src/main/java/io/dock2dock/android/barcodeScanner/models/BarcodeReaderConfig.kt
@@ -13,5 +13,6 @@ data class BarcodeReaderConfig(
     val interleaved25Enabled: Boolean = false,
     val pdf417Enabled: Boolean = false,
     val centerDecodeEnabled: Boolean = true,
-    val badReadNotificationEnabled: Boolean = true
+    val badReadNotificationEnabled: Boolean = true,
+    val goodReadNotificationEnabled: Boolean = true
 )

--- a/barcodeScanner/src/main/java/io/dock2dock/android/barcodeScanner/models/HoneywellBarcodeReader.kt
+++ b/barcodeScanner/src/main/java/io/dock2dock/android/barcodeScanner/models/HoneywellBarcodeReader.kt
@@ -55,6 +55,8 @@ class HoneywellBarcodeReader(
                     BarcodeReader.TRIGGER_CONTROL_MODE_CLIENT_CONTROL
                 )
 
+                reader?.setProperty(BarcodeReader.PROPERTY_NOTIFICATION_GOOD_READ_ENABLED, config.goodReadNotificationEnabled)
+
                 reader?.setProperty(BarcodeReader.PROPERTY_CODE_39_ENABLED, config.code39Enabled)
                 reader?.setProperty(BarcodeReader.PROPERTY_DATAMATRIX_ENABLED, config.dataMatrixEnabled)
                 reader?.setProperty(BarcodeReader.PROPERTY_CODE_128_ENABLED, config.code128Enabled)


### PR DESCRIPTION
## Summary
- Add `BarcodeReaderConfig.goodReadNotificationEnabled` (defaults to `true`) and wire it to `BarcodeReader.PROPERTY_NOTIFICATION_GOOD_READ_ENABLED` in `initialise()`, mirroring the existing `badReadNotificationEnabled` toggle.
- Previously the good-read beep was never explicitly set, so it stayed at whatever the device's default was and callers had no way to disable it.

## Test plan
- [x] `./gradlew :barcodeScanner:compileDebugKotlin` passes
- [ ] On a Honeywell device, confirm the good-read beep can be toggled off via `BarcodeReaderConfig(goodReadNotificationEnabled = false)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)